### PR TITLE
exclude-some-columns-from-report

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,8 +87,8 @@ Changes in your project
 
     class MyTable(TableReport):
 
-        exclude_from_report = ('column1', ...)
-
+        class Meta:
+            exclude_from_report = ('column1', ...)
         ...
 
 2.a. If you use a traditional views, now you should use other RequestConfig and change a little your view:

--- a/django_tables2_reports/tables.py
+++ b/django_tables2_reports/tables.py
@@ -93,6 +93,8 @@ class TableReport(tables.Table):
         self.formats = [(_('CSV Report'), 'csv')]
         if get_excel_support():
             self.formats.append((_('XLS Report'), 'xls'))
+        if hasattr(self, 'Meta'):
+            self.exclude_from_report = getattr(self.Meta, 'exclude_from_report', ())
 
     def _with_exclude_from_report(method):
         """ Put to 'exclude' columns from 'exclude_from_report', and revert this after method's call """

--- a/django_tables2_reports/tests.py
+++ b/django_tables2_reports/tests.py
@@ -138,7 +138,6 @@ class TestCsvGeneration(TestCase):
 
     def test_exclude_from_report(self):
         """Ensure that exclude-some-columns-from-report works."""
-
         data = [
             {
                 'name': 'page 1',
@@ -150,9 +149,13 @@ class TestCsvGeneration(TestCase):
             },
         ]
 
-        table = TableReportForTesting(data)
+        class TableWithExclude(TableReportForTesting):
+            class Meta:
+                exclude_from_report = ('item_num',)
+
+        table = TableWithExclude(data)
         table.exclude = ('name', )
-        table.exclude_from_report = ('item_num',)
+        self.assertEqual(table.exclude_from_report, ('item_num',))
 
         response = table.as_csv(HttpRequest())
         self.assertEqual(response.status_code, 200)
@@ -160,7 +163,7 @@ class TestCsvGeneration(TestCase):
         if PY3:
             content = content.decode(settings.DEFAULT_CHARSET).replace('\x00', '')
 
-        self.assertEqual(table.exclude, ('name',), "Attribute 'exclude_from_report' shouldn't overwrite 'exclude'")
+        self.assertEqual(table.exclude, ('name',))  # Attribute 'exclude_from_report' shouldn't overwrite 'exclude'
         self.assertEqual(
             content,
             ('Name\r\n'


### PR DESCRIPTION
Adds possibility to exclude specific columns from report.
Added a decorator on 'as_xls', 'as_csv' that before call of method sets table's 'exclude' to specilal attribute 'exlude_from_report', and after revert 'exclude' to original value.
I wait for guidance if this approach is not very good  :)
