### PR TITLE
check for tables2 meta template attribute

### DIFF
--- a/django_tables2_reports/tables.py
+++ b/django_tables2_reports/tables.py
@@ -42,7 +42,8 @@ from django.utils.html import strip_tags
 from django_tables2_reports import csv_to_xls
 from django_tables2_reports.utils import (DEFAULT_PARAM_PREFIX,
                                           get_excel_support,
-                                          generate_prefixto_report)
+                                          generate_prefixto_report,
+                                          check_for_template)
 
 
 # Unicode CSV writer, copied direct from Python docs:
@@ -85,8 +86,10 @@ class TableReport(tables.Table):
     exclude_from_report = ()  # the names of columns that should be excluded from report
 
     def __init__(self, *args, **kwargs):
-        if not 'template' in kwargs:
-            kwargs['template'] = 'django_tables2_reports/table.html'
+
+        if not check_for_template(self, kwargs): 
+           kwargs['template'] = 'django_tables2_reports/table.html'
+
         prefix_param_report = kwargs.pop('prefix_param_report', DEFAULT_PARAM_PREFIX)
         super(TableReport, self).__init__(*args, **kwargs)
         self.param_report = generate_prefixto_report(self, prefix_param_report)

--- a/django_tables2_reports/utils.py
+++ b/django_tables2_reports/utils.py
@@ -27,6 +27,15 @@ REPORT_CONTENT_TYPES = {
 REPORT_MYMETYPE = REPORT_CONTENT_TYPES['xls']  # backwards compatible
 
 
+def check_for_template(self, kwargs):
+    if not 'template' in kwargs and not hasattr(self, 'Meta'):
+        return False
+    elif not hasattr(self.Meta, 'template'):
+        return False
+    else:
+        return True
+
+
 def create_report_http_response(table, request):
     report_format = request.GET.get(table.param_report)
     report = table.as_report(request, report_format=report_format)


### PR DESCRIPTION
Custom Templates in django-tables2 are not only available via the keyword argument. The Code must also check the Meta.template attribute.
