### PR TITLE
Replace template with template_name to follow changes in django-tables2

### DIFF
--- a/django_tables2_reports/tables.py
+++ b/django_tables2_reports/tables.py
@@ -85,8 +85,8 @@ class TableReport(tables.Table):
     exclude_from_report = ()  # the names of columns that should be excluded from report
 
     def __init__(self, *args, **kwargs):
-        if not 'template' in kwargs:
-            kwargs['template'] = 'django_tables2_reports/table.html'
+        if not 'template_name' in kwargs:
+            kwargs['template_name'] = 'django_tables2_reports/table.html'
         prefix_param_report = kwargs.pop('prefix_param_report', DEFAULT_PARAM_PREFIX)
         super(TableReport, self).__init__(*args, **kwargs)
         self.param_report = generate_prefixto_report(self, prefix_param_report)

--- a/django_tables2_reports/tables.py
+++ b/django_tables2_reports/tables.py
@@ -78,6 +78,7 @@ class UnicodeWriter:
         self.stream.write(data)
         # empty queue
         self.queue.truncate(0)
+        self.queue.seek(0)
 
 
 class TableReport(tables.Table):


### PR DESCRIPTION
After this commit (8 may 2018):
`https://github.com/jieter/django-tables2/commit/38a0edf84a51064712ac8b5cbec876c7cbeb6033#diff-60ad7b203ea243e63b182237dc7d6190`
django-tables2 uses `template_name`  property instead `template` on Table class.